### PR TITLE
Email authentication preprocessing with Legit 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+.idea/*

--- a/README.md
+++ b/README.md
@@ -43,3 +43,6 @@ $ bin/www
 You can access <http://localhost:3000> on your web browser.
 
 ![](https://raw.github.com/outsideris/slack-invite-automation/master/screenshots/join-page.jpg)
+
+## Email Validation
+The `/invite` route makes use of the [legit](https://www.npmjs.com/package/legit) Node package to validate the MX record for an email's domain. Rather than using a regex this option has been used for more adequate email validation preprocessing.

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "morgan": "^1.6.0",
     "request": "^2.62.0",
     "serve-favicon": "^2.3.0",
-    "yamljs": "^0.2.4"
+    "yamljs": "^0.2.4",
+    "legit": "0.0.5"
   }
 }

--- a/routes/index.js
+++ b/routes/index.js
@@ -19,6 +19,19 @@ router.get('/rules', function(req, res) {
 });
 
 router.post('/invite', function(req, res) {
+
+  var checkEmail = require('legit');
+  // Checks for the existence of a MX record for the email address' domain
+  checkEmail(req.body.email, function(validation, addresses, err) {
+    if (!validation) {
+      res.render('result', {
+        community: config.community,
+        message: 'Failed. Email domain is invalid.',
+        isFailed: true
+      });
+    }
+  });
+
   if (req.body.email && (!config.inviteToken || (!!config.inviteToken && req.body.token === config.inviteToken))) {
     request.post({
         url: 'https://'+ config.slackUrl + '/api/users.admin.invite',


### PR DESCRIPTION
Add support for email authentication preprocessing with Legit Node package for issue #2! @kexline4710 I opted to use legit - https://www.npmjs.com/package/legit - since a regex is a huge pain in the neck (e.g. http://emailregex.com/). Legit does some preprocessing by ensuring that the domain in a given email address has an MX record - https://en.wikipedia.org/wiki/MX_record. More info from the author here should you be curious - https://sendgrid.com/blog/a-handy-library-to-ensure-email-addresses-are-legit/.
