### PR TITLE
add google recaptcha support

### DIFF
--- a/config.js
+++ b/config.js
@@ -14,5 +14,7 @@ module.exports = {
   //   --compressed
   slacktoken: process.env.SLACK_TOKEN || 'YOUR-ACCESS-TOKEN',
   // an optional security measure - if it is set, then that token will be required to get invited.
-  inviteToken: process.env.INVITE_TOKEN || null
+  inviteToken: process.env.INVITE_TOKEN || null,
+  // the google recaptcha private key
+  googleRecaptchaKey: process.env.GOOGLE_RECAPTCHA_PRIVATE_KEY || 'GOOGLE-RECAPTCHA-PRIVATE-KEY'
 };

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "morgan": "^1.6.0",
     "request": "^2.62.0",
     "serve-favicon": "^2.3.0",
+    "simple-recaptcha": "0.0.3",
     "yamljs": "^0.2.4"
   }
 }

--- a/routes/index.js
+++ b/routes/index.js
@@ -4,6 +4,7 @@ var request = require('request');
 var config = require('../config');
 var YAML = require('yamljs');
 var rules = YAML.load('./data/rules.yaml');
+var simple_recaptcha = require('simple-recaptcha');
 
 router.get('/', function(req, res) {
   res.render('index', { community: config.community,
@@ -19,70 +20,85 @@ router.get('/rules', function(req, res) {
 });
 
 router.post('/invite', function(req, res) {
-  if (req.body.email && (!config.inviteToken || (!!config.inviteToken && req.body.token === config.inviteToken))) {
-    request.post({
-        url: 'https://'+ config.slackUrl + '/api/users.admin.invite',
-        form: {
-          email: req.body.email,
-          token: config.slacktoken,
-          set_active: true
-        }
-      }, function(err, httpResponse, body) {
-        // body looks like:
-        //   {"ok":true}
-        //       or
-        //   {"ok":false,"error":"already_invited"}
-        if (err) { return res.send('Error:' + err); }
-        body = JSON.parse(body);
-        if (body.ok) {
-          res.render('result', {
-            community: config.community,
-            message: 'Success! Check "'+ req.body.email +'" for an invite from Slack.'
+  var privateKey = config.googleRecaptchaKey;
+  var ip = req.ip;
+  var recaptchaChallenge = req.body.recaptcha_challenge_field;
+  var recaptchaResponse = req.body.recaptcha_response_field;
+
+  simple_recaptcha(privateKey, ip, recaptchaChallenge, recaptchaResponse, function(err) {
+    if (err) {
+      res.render('result', {
+        community: config.community,
+        message: 'Failed! I think you are a robot.',
+        isFailed: true
+      });
+    } else {
+      if (req.body.email && (!config.inviteToken || (!!config.inviteToken && req.body.token === config.inviteToken))) {
+        request.post({
+            url: 'https://'+ config.slackUrl + '/api/users.admin.invite',
+            form: {
+              email: req.body.email,
+              token: config.slacktoken,
+              set_active: true
+            }
+          }, function(err, httpResponse, body) {
+            // body looks like:
+            //   {"ok":true}
+            //       or
+            //   {"ok":false,"error":"already_invited"}
+            if (err) { return res.send('Error:' + err); }
+            body = JSON.parse(body);
+            if (body.ok) {
+              res.render('result', {
+                community: config.community,
+                message: 'Success! Check "'+ req.body.email +'" for an invite from Slack.'
+              });
+            } else {
+              var error = body.error;
+              if (error === 'already_invited' || error === 'already_in_team') {
+                res.render('result', {
+                  community: config.community,
+                  message: 'Success! You were already invited.<br>' +
+                           'Visit to <a href="https://'+ config.slackUrl +'">'+ config.community +'</a>'
+                });
+                return;
+              } else if (error === 'invalid_email') {
+                error = 'The email you entered is an invalid email.'
+              } else if (error === 'invalid_auth') {
+                error = 'Something has gone wrong. Please contact a system administrator.'
+              }
+
+              res.render('result', {
+                community: config.community,
+                message: 'Failed! ' + error,
+                isFailed: true
+              });
+            }
           });
-        } else {
-          var error = body.error;
-          if (error === 'already_invited' || error === 'already_in_team') {
-            res.render('result', {
-              community: config.community,
-              message: 'Success! You were already invited.<br>' +
-                       'Visit to <a href="https://'+ config.slackUrl +'">'+ config.community +'</a>'
-            });
-            return;
-          } else if (error === 'invalid_email') {
-            error = 'The email you entered is an invalid email.'
-          } else if (error === 'invalid_auth') {
-            error = 'Something has gone wrong. Please contact a system administrator.'
+      } else {
+        var errMsg = [];
+        if (!req.body.email) {
+          errMsg.push('your email is required');
+        }
+
+        if (!!config.inviteToken) {
+          if (!req.body.token) {
+            errMsg.push('valid token is required');
           }
 
-          res.render('result', {
-            community: config.community,
-            message: 'Failed! ' + error,
-            isFailed: true
-          });
+          if (req.body.token && req.body.token !== config.inviteToken) {
+            errMsg.push('the token you entered is wrong');
+          }
         }
-      });
-  } else {
-    var errMsg = [];
-    if (!req.body.email) {
-      errMsg.push('your email is required');
-    }
 
-    if (!!config.inviteToken) {
-      if (!req.body.token) {
-        errMsg.push('valid token is required');
-      }
-
-      if (req.body.token && req.body.token !== config.inviteToken) {
-        errMsg.push('the token you entered is wrong');
+        res.render('result', {
+          community: config.community,
+          message: 'Failed! ' + errMsg.join(' and ') + '.',
+          isFailed: true
+        });
       }
     }
-
-    res.render('result', {
-      community: config.community,
-      message: 'Failed! ' + errMsg.join(' and ') + '.',
-      isFailed: true
-    });
-  }
+  });
 });
 
 module.exports = router;

--- a/views/index.jade
+++ b/views/index.jade
@@ -11,6 +11,7 @@ block content
         input(type="text", name="email", placeholder="Enter Your Email Address")#slack-email.field
         if tokenRequired
           input(type="text", name="token", placeholder="Enter the invite token you were given")#slack-token.field
+        .g-recaptcha(data-sitekey="6Lc1NBgTAAAAAK0u6KHdA3wm-DyzrFcA2J87RpUs")
         input(type="submit", value="Join").submit
 script.
   var tokenRequired = #{tokenRequired};

--- a/views/layout.jade
+++ b/views/layout.jade
@@ -6,6 +6,7 @@ html
     title Join the #{community} community on Slack!
     link(href="css/style.css", rel="stylesheet", type="text/css")
     link(href="http://fonts.googleapis.com/css?family=Lato:300,400,700,900,700italic|Open+Sans:700italic,400,600,300,700,800", rel="stylesheet", type="text/css")
+    script(src='https://www.google.com/recaptcha/api.js' async defer)
   body
     #wrapper
       nav


### PR DESCRIPTION
To solve issue #4 

I opted to use the simple-recaptcha module because of its, yes, simple
implementation of the the google captcha. Since it's a reasonable
captcha that is accessible I think it will work nicely. Documentation
for the module is [here](https://github.com/zeMirco/simple-recaptcha).

@lorenanicole @lrakhman 
