### PR TITLE
Feature/handrolled recaptcha

### DIFF
--- a/config.js
+++ b/config.js
@@ -14,5 +14,10 @@ module.exports = {
   //   --compressed
   slacktoken: process.env.SLACK_TOKEN || 'YOUR-ACCESS-TOKEN',
   // an optional security measure - if it is set, then that token will be required to get invited.
-  inviteToken: process.env.INVITE_TOKEN || null
+  inviteToken: process.env.INVITE_TOKEN || null,
+
+  // google site key (this is public)
+  recaptchaSiteKey: process.env.GOOGLE_RECAPTCHA_SITE_KEY || '6Lc1NBgTAAAAAK0u6KHdA3wm-DyzrFcA2J87RpUs',
+  // google private recaptcha key (keep this hidden)
+  privateRecaptchaKey: process.env.GOOGLE_RECAPTCHA_PRIVATE_KEY || 'PRIVATE-RECAPTCHA-KEY',
 };

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "cookie-parser": "^1.4.0",
     "debug": "^2.2.0",
     "express": "^4.13.0",
+    "https": "^1.0.0",
     "jade": "^1.11.0",
     "morgan": "^1.6.0",
     "request": "^2.62.0",

--- a/routes/index.js
+++ b/routes/index.js
@@ -5,74 +5,103 @@ var config = require('../config');
 
 router.get('/', function(req, res) {
   res.render('index', { community: config.community,
-                        tokenRequired: !!config.inviteToken });
+                        tokenRequired: !!config.inviteToken,
+                        recaptchaSiteKey: config.recaptchaSiteKey });
 });
 
 router.post('/invite', function(req, res) {
-  if (req.body.email && (!config.inviteToken || (!!config.inviteToken && req.body.token === config.inviteToken))) {
-    request.post({
-        url: 'https://'+ config.slackUrl + '/api/users.admin.invite',
-        form: {
-          email: req.body.email,
-          token: config.slacktoken,
-          set_active: true
-        }
-      }, function(err, httpResponse, body) {
-        // body looks like:
-        //   {"ok":true}
-        //       or
-        //   {"ok":false,"error":"already_invited"}
-        if (err) { return res.send('Error:' + err); }
-        body = JSON.parse(body);
-        if (body.ok) {
-          res.render('result', {
-            community: config.community,
-            message: 'Success! Check "'+ req.body.email +'" for an invite from Slack.'
+  verifyRecaptcha(req.body["g-recaptcha-response"], function(success) {
+    if (success) {
+      if (req.body.email && (!config.inviteToken || (!!config.inviteToken && req.body.token === config.inviteToken))) {
+        request.post({
+            url: 'https://'+ config.slackUrl + '/api/users.admin.invite',
+            form: {
+              email: req.body.email,
+              token: config.slacktoken,
+              set_active: true
+            }
+          }, function(err, httpResponse, body) {
+            // body looks like:
+            //   {"ok":true}
+            //       or
+            //   {"ok":false,"error":"already_invited"}
+            if (err) { return res.send('Error:' + err); }
+            body = JSON.parse(body);
+            if (body.ok) {
+              res.render('result', {
+                community: config.community,
+                message: 'Success! Check "'+ req.body.email +'" for an invite from Slack.'
+              });
+            } else {
+              var error = body.error;
+              if (error === 'already_invited' || error === 'already_in_team') {
+                res.render('result', {
+                  community: config.community,
+                  message: 'Success! You were already invited.<br>' +
+                           'Visit to <a href="https://'+ config.slackUrl +'">'+ config.community +'</a>'
+                });
+                return;
+              } else if (error === 'invalid_email') {
+                error = 'The email you entered is an invalid email.'
+              } else if (error === 'invalid_auth') {
+                error = 'Something has gone wrong. Please contact a system administrator.'
+              }
+
+              res.render('result', {
+                community: config.community,
+                message: 'Failed! ' + error,
+                isFailed: true
+              });
+            }
           });
-        } else {
-          var error = body.error;
-          if (error === 'already_invited' || error === 'already_in_team') {
-            res.render('result', {
-              community: config.community,
-              message: 'Success! You were already invited.<br>' +
-                       'Visit to <a href="https://'+ config.slackUrl +'">'+ config.community +'</a>'
-            });
-            return;
-          } else if (error === 'invalid_email') {
-            error = 'The email you entered is an invalid email.'
-          } else if (error === 'invalid_auth') {
-            error = 'Something has gone wrong. Please contact a system administrator.'
+      } else {
+        var errMsg = [];
+        if (!req.body.email) {
+          errMsg.push('your email is required');
+        }
+
+        if (!!config.inviteToken) {
+          if (!req.body.token) {
+            errMsg.push('valid token is required');
           }
 
-          res.render('result', {
-            community: config.community,
-            message: 'Failed! ' + error,
-            isFailed: true
-          });
+          if (req.body.token && req.body.token !== config.inviteToken) {
+            errMsg.push('the token you entered is wrong');
+          }
         }
+
+        res.render('result', {
+          community: config.community,
+          message: 'Failed! ' + errMsg.join(' and ') + '.',
+          isFailed: true
+        });
+      }
+    } else {
+      res.render('result', {
+        community: config.community,
+        message: 'Failed! Google thinks you are a robot.',
+        isFailed: true
       });
-  } else {
-    var errMsg = [];
-    if (!req.body.email) {
-      errMsg.push('your email is required');
     }
-
-    if (!!config.inviteToken) {
-      if (!req.body.token) {
-        errMsg.push('valid token is required');
-      }
-
-      if (req.body.token && req.body.token !== config.inviteToken) {
-        errMsg.push('the token you entered is wrong');
-      }
-    }
-
-    res.render('result', {
-      community: config.community,
-      message: 'Failed! ' + errMsg.join(' and ') + '.',
-      isFailed: true
-    });
-  }
+  });
 });
+
+function verifyRecaptcha(captchaResponse, callback) {
+  https.get("https://www.google.com/recaptcha/api/siteverify?secret=" + config.privateRecaptchaKey + "&response=" + captchaResponse, function(res){
+    var data = "";
+    res.on('data', function (chunk) {
+      data += chunk.toString();
+    });
+    res.on('end', function () {
+      try {
+        var parsedData = JSON.parse(data);
+        callback(parsedData.success);
+      }
+      catch (e) {
+        callback(false);
+      }
+    });
+  });
+}
 
 module.exports = router;

--- a/views/result.jade
+++ b/views/result.jade
@@ -6,6 +6,7 @@ html
     title Join the #{community} community on Slack!
     link(href="css/style.css", rel="stylesheet", type="text/css")
     link(href="http://fonts.googleapis.com/css?family=Lato:300,400,700,900,700italic|Open+Sans:700italic,400,600,300,700,800", rel="stylesheet", type="text/css")
+    script(src='https://www.google.com/recaptcha/api.js')
   body
     #wrapper
       .main


### PR DESCRIPTION
I tinkered with using some node modules to handle the recaptcha like `simple-recaptcha`, but the configuration always seemed to give me trouble. Thus, it seemed simpler to just handle the verification without the use of a module as shown [here](https://jaxbot.me/articles/new-nocaptcha-recaptcha-with-node-js-express-12-9-2014).

There are a lot of indentation changes so I recommend viewing this page without the whitespace (add `?w=1` to the end of the url above).

Solves this issue: https://github.com/chitechdiversity/slack-invite-automation/issues/4
